### PR TITLE
Fixed and streamlined framework init bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,22 @@
 # Pragma
 
-Build websites the way you want. This framework is designed to interfere *as little as possible* with how you write your code and let you decide how your website should look and behave. It covers the basics of an otherwise vanilla PHP, JavaScript, and CSS website - that don't rely on preprocessors (such as SASS or TypeScript) offered by the framework itself, *but those features can of course be implemented downstream*.
+Build websites the way you want. This framework is designed to interfere *as little as possible* with how you write your code and let you decide how your website should look, feel, and behave. This framework will take care of interactions, navigation, and asset imports; only.
 
 ## 🤷 What's the point?
 
-Frameworks today tend to encourage developers to follow certain rules when making new websites. *This is of course useful* and those frameworks should ***probaby*** be used instead. The goal of Pragma is to tackle *only* the following when the goal is to build a website *from sratch*:
-
-- Navigation (SPA-like)
-- Localization
-- Interaction
-- Bundling
-
-The rest is up to the developer to figure out.
+**TLDR;**
 
 ![meme](https://user-images.githubusercontent.com/35688133/204326222-236a71be-5ea3-4653-8caa-6f6cfcd0d0d6.png)
 
-This is what Pragma is trying to solve. Need to connect to a database, need to send automatic mails? Do it your way!
+Pragma is a foundation for a vanilla PHP website (with optional vanilla JS and CSS). It wont abstract away stuff like connecting to databases, sending emails, or call APIs.
 
-# Examples
+---
 
-Check out the [GeneMate<sup>®</sup> by iCellate](https://genemate.se) website, which spawned this project, if you wish to see Pragma used in production. And here are a few examples of how websites can be built with Pragma:
+Check out [GeneMate<sup>®</sup> by iCellate](https://genemate.se) if you wish to see Pragma used in production.
 
-### The simplest website in Pragma
+---
+
+## Example
 
 No bells and whistles? Build static websites with only one page.
 
@@ -38,8 +33,10 @@ No bells and whistles? Build static websites with only one page.
   <img src="/assets/media/coolpic.webp" alt="A cool picture"/>
   <!-- Using data-trigger will call the method with data-action -->
   <button data-trigger="document" data-trigger="myCoolMethod">Click to say the magic word!</button>
+  <!-- This will load in Pragma's interaction and navigation handlers -->
+  <script><?= Page::init() ?></script>
   <!-- Will import and minify the JS file at "/assets/js/pages/script.js" -->
-  <script><? Page::js("pages/script") ?></script>
+  <script><?= Page::js("pages/script") ?></script>
 </body>
 </html>
 ```

--- a/src/frontend/bundle.php
+++ b/src/frontend/bundle.php
@@ -1,0 +1,3 @@
+<?= Page::js(Path::pragma("src/frontend/js/modules/Navigation.js"), false) ?>
+<?= Page::js(Path::pragma("src/frontend/js/modules/Interactions.js"), false) ?>
+<?= Page::js(Path::pragma("src/frontend/js/pragma.js"), false) ?>

--- a/src/frontend/pragma.php
+++ b/src/frontend/pragma.php
@@ -1,3 +1,0 @@
-<?= Page::js("modules/Navigation.js") ?>
-<?= Page::js("modules/Interactions.js") ?>
-<?= Page::js("pragma.js") ?>

--- a/src/request/Page.php
+++ b/src/request/Page.php
@@ -76,8 +76,10 @@
 		// with the static reference Page::<method> anywhere on the page.
 
 		// Return minified CSS from file
-		public static function css(string $file): string {
-			$file = Page::get_asset_path("css", $file);
+		public static function css(string $file, bool $relative = true): string {
+			// Get assets/css relative from site path unless the relative flag is set.
+			// An unset relative flag will make the path absolute.
+			$file = $relative ? Page::get_asset_path("css", $file) : $file;
 
 			if(!is_file($file)) {
 				return "";
@@ -88,8 +90,10 @@
 		}
 
 		// Return minified JS from file
-		public static function js(string $file): string {
-			$file = Page::get_asset_path("js", $file);
+		public static function js(string $file, bool $relative = true): string {
+			// Get assets/js relative from site path unless the relative flag is set.
+			// An unset relative flag will make the path absolute.
+			$file = $relative ? Page::get_asset_path("js", $file) : $file;
 
 			if(!is_file($file)) {
 				return "";
@@ -101,8 +105,10 @@
 
 		// Return contents of media file as base64-encoded string unless whitelisted
 		// for assets that should be read as-is, such as SVG.
-		public static function media(string $file): string {
-			$file = file_get_contents(Page::get_asset_path("media", $file));
+		public static function media(string $file, bool $relative = true): string {
+			// Get assets/media relative from site path unless the relative flag is set.
+			// An unset relative flag will make the path absolute.
+			$file = $relative ? file_get_contents(Page::get_asset_path("media", $file)) : $file;
 
 			// Invalid file returns empty string
 			if ($file === false) {
@@ -119,7 +125,7 @@
 
 		// Load an external document into the current document
 		public static function include(string $name) {
-			// Rewrite root to /main page
+			// Rewrite empty path to "index" page
 			if ($name === "/") {
 				$name = "/index";
 			}
@@ -128,11 +134,10 @@
 			$locale = Page::get_locale();
 			$file = Path::root("pages/${locale}/${name}.php");
 
-			// If user content page does not exist, try to load from framework
-			if (!is_file($file)) {
-				$file = Path::pragma("src/frontend/${name}.php");
-			}
-
 			include $file;
+		}
+
+		public static function init() {
+			include Path::pragma("src/frontend/bundle.php");
 		}
 	}


### PR DESCRIPTION
Replaced the old syntax:
```php
<script><?= Page::js("pragma") ?></script>
```
with
```php
<script><?= Page::init() ?></script>
```

It essentially does the same thing but makes it clearar what it does. And it also won't clash with any site asset called "pragma.js" like the old syntax did