### PR TITLE
Add page load and unload navigation events and bugfixes

### DIFF
--- a/src/frontend/js/pragma.js
+++ b/src/frontend/js/pragma.js
@@ -9,6 +9,8 @@ globalThis.pragma = {
 	Navigation: (...args) => new Navigation(...args)
 };
 
+globalThis.pragma.Navigation(window.location.pathname.length > 1 ? window.location.pathname : "/index").navigate(document.querySelector("main"));
+
 // Handle browser back/forward buttons
 window.addEventListener("popstate", (event) => {
 	if ("url" in event.state) {

--- a/src/request/Page.php
+++ b/src/request/Page.php
@@ -116,7 +116,7 @@
 			}
 
 			// Base64-encode everything that isn't in whitelist array
-			if (!in_array(substr($file, -1, 4), [".svg"])) {
+			if (!preg_match("//u", $file)) {
 				$file = base64_encode($file);
 			}
 			

--- a/src/request/Page.php
+++ b/src/request/Page.php
@@ -3,7 +3,7 @@
 	use MatthiasMullie\Minify;
 
 	class Page {
-		public function __construct($page = "document") {
+		public function __construct(string $page = "document") {
 			// Check if request is for partial content
 			if (array_key_exists("HTTP_X_NAVIGATION_TYPE", $_SERVER)) {
 				switch ($_SERVER["HTTP_X_NAVIGATION_TYPE"]) {
@@ -20,6 +20,11 @@
 				// Serve the whole document on (re)load
 				Page::include("document");
 			}
+		}
+
+		private static function error(int $code): never {
+			http_response_code($code);
+			exit();
 		}
 
 		// Return absolute path to asset on disk.
@@ -133,6 +138,10 @@
 			// Attempt to load from user content pages
 			$locale = Page::get_locale();
 			$file = Path::root("pages/${locale}/${name}.php");
+
+			if (!is_file($file)) {
+				return Page::error(404);
+			}
 
 			include $file;
 		}

--- a/src/request/Request.php
+++ b/src/request/Request.php
@@ -18,11 +18,11 @@
 		private function router() {
 			switch ($this->path) {
 				// Get static asset from user content
-				case (preg_match(Request::$preg_asset, $this->path) ? true : false):
+				case (preg_match($this::$preg_asset, $this->path) ? true : false):
 					return $this->asset();
 				
 				// Return script to be run in a JS Worker
-				case (preg_match(Request::$preg_worker, $this->path) ? true : false):
+				case (preg_match($this::$preg_worker, $this->path) ? true : false):
 					return $this->worker();
 
 				// Ignore requests to /favicon.ico which sometimes gets sent automatically


### PR DESCRIPTION
This PR adds a new feature which dispatches events to `window` and the element which is having its subtree navigated.

Also fixes a bug with initial page loading