### PR TITLE
Added optional custom error pages support

### DIFF
--- a/.env.example.ini
+++ b/.env.example.ini
@@ -1,18 +1,37 @@
-; Pragma environment variables
-
+; ------------------------------------------------
 ; # Your website
 ; Absolute path to the root of your site contents.
+; ------------------------------------------------
+
 site_path = ""
 
-; # Root element selector
+; -----------------
+; # Fontend set-up
+; -----------------
+
+; ## Root element selector
 ; The CSS selector of root element which the main page is contained in.
 ; See X for more information about the Pragma root element.
+
 selector_main_element = "main"
 
-; # Document page
+; ## Document page
 ; Relative file name from "pages/" of the page to should be used as app shell
+
 page_document = "document"
 
-; # Landingpage
+; ## Landingpage
 ; Relative file name from "pages/" of the page that should be loaded when no path provided (landingpage)
+
 page_index = "index"
+
+; ---------------------------------------------------------
+; # Optional features
+; Uncomment lines to enable and configure optional features
+; ---------------------------------------------------------
+
+; ## Custom error page
+; Relative path (from your "site_path") to a page to load on 4xx-5xx HTTP response codes
+; https://github.com/VictorWesterlund/pragma/wiki/Optional-features#custom-error-page
+
+;error_page_path = ""

--- a/src/frontend/js/workers/NavigationWorker.js
+++ b/src/frontend/js/workers/NavigationWorker.js
@@ -5,23 +5,12 @@ class NavigationWorker {
 		this.getPage();	
 	}
 
-	// Create an empty Response with a status code only
-	newEmptyResponse(code = 500, message = "Pragma:NavigationWorker: Internal Server Error") {
-		return new Response(null, {
-			status: code,
-			statusText: message
-		});
-	}
-
 	async send(response) {
-		// Didn't get a response object
-		if (!response instanceof Response) {
-			return globalThis.postMessage([-1, null]);
-		}
-
-		const body = await response.text();
-
-		globalThis.postMessage([body, response.status, response.url]);
+		return response instanceof Response 
+			// Return page as plaintext along with the response HTTP status and the fetched URL
+			? globalThis.postMessage([await response.text(), response.status, response.url])
+			// Didn't get a response object
+			: globalThis.postMessage([-1, null]);
 	}
 
 	// Request page from back-end


### PR DESCRIPTION
This pull request adds a new feature to the Pragma web router framework, allowing developers to define optional error pages. If an error occurs during routing, such as a 404 error for a missing page, the framework will now check for an optional error page definition and display it instead of just `exit()`ing.

This feature provides developers with more control over the error handling process and allows for a more customized and user-friendly error page experience. The error page definition can be configured through `.env.ini`.

# Benefits

- Customized error handling: Developers can define their own error pages to provide a more customized and branded error page experience for their users.
- Better user experience: Instead of generic error messages, users will see more informative and visually appealing error pages, which can help improve their overall experience on the website.
- Enhanced error tracking: Custom error pages can include additional error tracking and logging mechanisms to help diagnose and resolve issues more effectively.

# Conclusion

The addition of the optional error page definition feature enhances Pragma by providing developers with more control over error handling and allowing for more customized error page experiences. This pull request will be merged to improve the framework's error handling capabilities and overall user experience.